### PR TITLE
Fix a bug that IO.delete deletes unintended directories.

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -96,7 +96,8 @@ object ProtocPlugin extends AutoPlugin {
       if (f.crossVersion) CrossVersion.binary else CrossVersion.Disabled)
 
   private[this] def compile(protocCommand: Seq[String] => Int, schemas: Set[File], includePaths: Seq[File], protocOptions: Seq[String], targets: Seq[Target], pythonExe: String, deleteTargetDirectory: Boolean, log: Logger) = {
-    val generatedTargetDirs = targets.map(_.outputPath)
+    // Sort by the length of path names to ensure that delete parent directories before deleting child directories.
+    val generatedTargetDirs = targets.map(_.outputPath).sortBy(_.getAbsolutePath.length)
     generatedTargetDirs.foreach{ targetDir =>
       if (deleteTargetDirectory) {
         IO.delete(targetDir)


### PR DESCRIPTION
Hi. I found a bug that sbt-protoc can't create output directories for `protoc` when multiple settings are given. It seems that deleting a parent directory causes this bug, so I modified the `compile` method defined at `ProtocPlugin` to delete parent directories first.

# how to reproduce the issue
```scala
// build.sbt
lazy val root = (project in file(".")).
  settings(
    name := "hello",
    version := "1.0",
    scalaVersion := "2.11.8",
    PB.targets in Compile := Seq(
      PB.gens.js -> (sourceManaged in Compile).value / "js" / "test",
      PB.gens.js -> (sourceManaged in Compile).value / "js",
      PB.gens.js -> (sourceManaged in Compile).value / "js" / "foo",
      scalapb.gen() -> (sourceManaged in Compile).value // NOTE: this line deletes /js/test, /js and /js/foo also.
    )
  )
```

```scala
// project/pluigins.sbt
addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.2")

libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.41"
```

```
// src/main/protobuf/test.proto
syntax = "proto2";

package myproto;

message Test {
  optional int32 foo = 1;
}
```

With the above settings, then run `sbt clean compile`. And the output is the following:

```bash
[success] Total time: 0 s, completed 2016/11/16 19:25:13
[info] Updating {file:/private/tmp/foo/}root...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Compiling 1 protobuf files to /private/tmp/foo/target/scala-2.11/src_managed/main/js/test,/private/tmp/foo/target/scala-2.11/src_managed/main/js,/private/tmp/foo/target/scala-2.11/src_managed/main/js/foo,/private/tmp/foo/target/scala-2.11/src_managed/main
[info] Compiling schema /private/tmp/foo/src/main/protobuf/test.proto
protoc-jar: protoc version: 300, detected platform: mac os x/x86_64
protoc-jar: executing: [/var/folders/rd/l_kv2kb92hj9vjlqpl7b3sgw0000gn/T/protoc1896358233649498529.exe, --plugin=protoc-gen-scala=/var/folders/rd/l_kv2kb92hj9vjlqpl7b3sgw0000gn/T/protocbridge9212655704878487989, --js_out=:/private/tmp/foo/target/scala-2.11/src_managed/main/js/test, --js_out=:/private/tmp/foo/target/scala-2.11/src_managed/main/js, --js_out=:/private/tmp/foo/target/scala-2.11/src_managed/main/js/foo, --scala_out=:/private/tmp/foo/target/scala-2.11/src_managed/main, -I/private/tmp/foo/src/main/protobuf, -I/private/tmp/foo/target/protobuf_external, /private/tmp/foo/src/main/protobuf/test.proto]
/private/tmp/foo/target/scala-2.11/src_managed/main/js/test/: No such file or directory
java.lang.RuntimeException: protoc returned exit code: 1
        at scala.sys.package$.error(package.scala:27)
        at sbtprotoc.ProtocPlugin$.sbtprotoc$ProtocPlugin$$compile(ProtocPlugin.scala:111)
        at sbtprotoc.ProtocPlugin$$anonfun$sourceGeneratorTask$1$$anonfun$4.apply(ProtocPlugin.scala:138)
        at sbtprotoc.ProtocPlugin$$anonfun$sourceGeneratorTask$1$$anonfun$4.apply(ProtocPlugin.scala:137)
        at sbt.FileFunction$$anonfun$cached$1.apply(Tracked.scala:253)
        at sbt.FileFunction$$anonfun$cached$1.apply(Tracked.scala:253)
        at sbt.FileFunction$$anonfun$cached$2$$anonfun$apply$3$$anonfun$apply$4.apply(Tracked.scala:267)
        at sbt.FileFunction$$anonfun$cached$2$$anonfun$apply$3$$anonfun$apply$4.apply(Tracked.scala:263)
        at sbt.Difference.apply(Tracked.scala:224)
        at sbt.Difference.apply(Tracked.scala:206)
        at sbt.FileFunction$$anonfun$cached$2$$anonfun$apply$3.apply(Tracked.scala:263)
        at sbt.FileFunction$$anonfun$cached$2$$anonfun$apply$3.apply(Tracked.scala:262)
        at sbt.Difference.apply(Tracked.scala:224)
        at sbt.Difference.apply(Tracked.scala:200)
        at sbt.FileFunction$$anonfun$cached$2.apply(Tracked.scala:262)
        at sbt.FileFunction$$anonfun$cached$2.apply(Tracked.scala:260)
        at sbtprotoc.ProtocPlugin$$anonfun$sourceGeneratorTask$1.apply(ProtocPlugin.scala:147)
        at sbtprotoc.ProtocPlugin$$anonfun$sourceGeneratorTask$1.apply(ProtocPlugin.scala:133)
        at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
        at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
        at sbt.std.Transform$$anon$4.work(System.scala:63)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
        at sbt.Execute.work(Execute.scala:237)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
        at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
[error] (compile:protocGenerate) protoc returned exit code: 1
[error] Total time: 0 s, completed 2016/11/16 19:25:13
```