### PR TITLE
Support for copying .proto files from dependency modules

### DIFF
--- a/src/sbt-test/sbt-protoc/multimodule/build.sbt
+++ b/src/sbt-test/sbt-protoc/multimodule/build.sbt
@@ -1,0 +1,21 @@
+lazy val pbSettings = Seq(
+  PB.targets in Compile := Seq(
+    scalapb.gen() -> (sourceManaged in Compile).value
+  ),
+  libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.0.0" % "protobuf",
+  unmanagedResourceDirectories in Compile += (baseDirectory in Compile).value / "src/main/protobuf"
+)
+
+lazy val root = project.in(file("."))
+  .aggregate(moduleA, moduleB)
+
+lazy val moduleA = project.in(file("module_a"))
+  .settings(
+    pbSettings: _*
+  )
+
+lazy val moduleB = project.in(file("module_b"))
+  .dependsOn(moduleA)
+  .settings(
+    pbSettings: _*
+  )

--- a/src/sbt-test/sbt-protoc/multimodule/module_a/src/main/protobuf/module_a/a.proto
+++ b/src/sbt-test/sbt-protoc/multimodule/module_a/src/main/protobuf/module_a/a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package moduleA;
+
+message AMessage {
+}
+

--- a/src/sbt-test/sbt-protoc/multimodule/module_b/src/main/protobuf/module_b/b.proto
+++ b/src/sbt-test/sbt-protoc/multimodule/module_b/src/main/protobuf/module_b/b.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "module_a/a.proto";
+
+package moduleB;
+
+message BMessage {
+    moduleA.AMessage aMessage = 1;
+}

--- a/src/sbt-test/sbt-protoc/multimodule/project/plugins.sbt
+++ b/src/sbt-test/sbt-protoc/multimodule/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.thesamet" % "sbt-protoc" % pluginVersion)
+}
+
+libraryDependencies ++= Seq(
+  "com.trueaccord.scalapb" %% "compilerplugin" % "0.5.41"
+)

--- a/src/sbt-test/sbt-protoc/multimodule/test
+++ b/src/sbt-test/sbt-protoc/multimodule/test
@@ -1,0 +1,10 @@
+> compile
+
+$ exists module_a/target/scala-2.10/src_managed/main/moduleA/a/AMessage.scala
+$ exists module_a/target/scala-2.10/classes/moduleA/a/AMessage.class
+
+$ exists module_b/target/scala-2.10/src_managed/main/moduleB/b/BMessage.scala
+$ exists module_b/target/scala-2.10/classes/moduleB/b/BMessage.class
+
+-$ exists module_b/target/scala-2.10/src_managed/main/moduleA/a/AMessage.scala
+-$ exists module_b/target/scala-2.10/classes/moduleB/b/AMessage.class


### PR DESCRIPTION
.proto files are only unzipped from libraries on the managed dependency classpath. This change copies .proto files from modules in the same multi-module build that we depend on, in addition, enabling inter-module dependencies between .proto files in the same aggregate build.