### PR TITLE
avoid overwrite some keys

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -87,16 +87,18 @@ object ProtocPlugin extends AutoPlugin {
     ),
     PB.recompile := arguments.previous.exists(_ != arguments.value),
     PB.protocOptions := Nil,
+    PB.protocOptions := PB.protocOptions.?.value.getOrElse(Nil),
 
     PB.unpackDependencies := unpackDependenciesTask(PB.unpackDependencies).value,
 
-    PB.protoSources := Nil,
+    PB.protoSources := PB.protoSources.?.value.getOrElse(Nil),
     PB.protoSources += sourceDirectory.value / "protobuf",
 
-    PB.includePaths := PB.protoSources.value,
+    PB.includePaths := PB.includePaths.?.value.getOrElse(Nil),
+    PB.includePaths ++= PB.protoSources.value,
     PB.includePaths += PB.externalIncludePath.value,
 
-    PB.targets := Nil,
+    PB.targets := PB.targets.?.value.getOrElse(Nil),
 
     PB.generate := sourceGeneratorTask(PB.generate).dependsOn(PB.unpackDependencies).value,
     sourceGenerators += PB.generate.taskValue

--- a/src/sbt-test/sbt-protoc/testconfig/build.sbt
+++ b/src/sbt-test/sbt-protoc/testconfig/build.sbt
@@ -1,7 +1,7 @@
-Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
-
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.1.0" % "protobuf"
 
 PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value)
 
 PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value)
+
+Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)


### PR DESCRIPTION
#### before

```scala
// ignore this line. there is no effect
PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value)

Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
```

<hr />

```scala
Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)

// ok
PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value)
```


<hr />


#### after

```scala
// ok
PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value)

Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
```


<hr />


```scala
// also ok
Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)

PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value)
```