### PR TITLE
Add tests and implementation for including sub-project proto.

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -210,12 +210,14 @@ object ProtocPlugin extends AutoPlugin with Compat {
 
     val thisProjectDeps = getAllProjectDeps(thisProjectRef.value)()
 
-    thisProjectDeps.map(ref => PB.protoSources in (ref, Compile)).foldLeft(Def.setting(Seq.empty[File])) {
-      case (acc, seq) => Def.settingDyn {
-        val values = acc.value ++ seq.value
-        Def.setting(values)
+    thisProjectDeps
+      .map(ref => (PB.protoSources in (ref, Compile), PB.includePaths in (ref, Compile)))
+      .foldLeft(Def.setting(Seq.empty[File])) {
+        case (acc, (srcs, includes)) => Def.settingDyn {
+          val values = acc.value ++ srcs.value ++ includes.value
+          Def.setting(values.distinct)
+        }
       }
-    }
   }
 
 }

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -213,8 +213,6 @@ object ProtocPlugin extends AutoPlugin {
 
     val thisProjectDeps = getAllProjectDeps(thisProjectRef.value)()
 
-    println(thisProjectDeps)
-
     thisProjectDeps.map(ref => PB.protoSources in (ref, Compile)).foldLeft(Def.setting(Seq.empty[File])) {
       case (acc, seq) => Def.settingDyn {
         val values = acc.value ++ seq.value

--- a/src/sbt-test/sbt-protoc/depends-on/build.sbt
+++ b/src/sbt-test/sbt-protoc/depends-on/build.sbt
@@ -16,3 +16,28 @@ lazy val commonSettings = Seq[SettingsDefinition](
   Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
   libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
 )
+
+def checkFile(state: State, settingKey: SettingKey[File], path: String): State = {
+  val extracted = Project.extract(state)
+  val targetDir = extracted.get(settingKey)
+  val targetFile = targetDir./(path)
+  if (!targetFile.exists())
+    sys.error(s"File $path does not exist in ${targetDir.getAbsolutePath}")
+  state
+}
+
+
+def makeExistsCommand(name: String, key: SettingKey[File]): Command =
+  Command.single(name){
+    (state: State, path: String) => checkFile(state, key, path)
+  }
+
+val existsSource: Command = makeExistsCommand("existsSource", sourceManaged in Compile)
+val existsASource: Command = makeExistsCommand("existsASource", sourceManaged in (a, Compile))
+val existsBSource: Command = makeExistsCommand("existsBSource", sourceManaged in (b, Compile))
+
+val existsClass: Command = makeExistsCommand("existsClass", classDirectory in Compile)
+val existsAClass: Command = makeExistsCommand("existsAClass", classDirectory in (a, Compile))
+val existsBClass: Command = makeExistsCommand("existsBClass", classDirectory in (b, Compile))
+
+commands ++= List(existsSource, existsClass, existsAClass, existsASource, existsBClass, existsBSource)

--- a/src/sbt-test/sbt-protoc/depends-on/build.sbt
+++ b/src/sbt-test/sbt-protoc/depends-on/build.sbt
@@ -11,8 +11,8 @@ lazy val b = (project in file("sub-b"))
 
 
 lazy val commonSettings = Seq[SettingsDefinition](
-  PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value),
-  PB.targets in Test := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Test).value),
+  PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value),
+  PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value),
   Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
   libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
 )

--- a/src/sbt-test/sbt-protoc/depends-on/build.sbt
+++ b/src/sbt-test/sbt-protoc/depends-on/build.sbt
@@ -1,0 +1,18 @@
+val protobufVersion = "3.3.1"
+
+lazy val root = (project in file("."))
+  .dependsOn(a).settings(commonSettings: _*)
+
+lazy val a = (project in file("sub-a"))
+  .dependsOn(b).settings(commonSettings: _*)
+
+lazy val b = (project in file("sub-b"))
+  .settings(commonSettings: _*)
+
+
+lazy val commonSettings = Seq[SettingsDefinition](
+  PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value),
+  PB.targets in Test := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Test).value),
+  Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
+  libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
+)

--- a/src/sbt-test/sbt-protoc/depends-on/project/plugins.sbt
+++ b/src/sbt-test/sbt-protoc/depends-on/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.thesamet" % "sbt-protoc" % pluginVersion)
+}

--- a/src/sbt-test/sbt-protoc/depends-on/src/main/protobuf/file1.proto
+++ b/src/sbt-test/sbt-protoc/depends-on/src/main/protobuf/file1.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package multi;
+
+import "a.proto";
+import "b.proto";
+
+message msg1 {
+  int32 thing = 1;
+  sub.a.msg1 sub_a = 2;
+  sub.b.msg1 sub_b = 3;
+}

--- a/src/sbt-test/sbt-protoc/depends-on/sub-a/src/main/protobuf/a.proto
+++ b/src/sbt-test/sbt-protoc/depends-on/sub-a/src/main/protobuf/a.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "b.proto";
+
+package sub.a;
+
+message msg1 {
+  int32 thing = 1;
+  sub.b.msg1 b_sub = 2;
+}

--- a/src/sbt-test/sbt-protoc/depends-on/sub-b/src/main/protobuf/b.proto
+++ b/src/sbt-test/sbt-protoc/depends-on/sub-b/src/main/protobuf/b.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package sub.b;
+
+message msg1 {
+  int32 thing = 1;
+}

--- a/src/sbt-test/sbt-protoc/depends-on/test
+++ b/src/sbt-test/sbt-protoc/depends-on/test
@@ -1,0 +1,14 @@
+> compile
+
+$ exists target/scala-2.10/src_managed/main/multi/File1.java
+$ exists target/scala-2.10/classes/multi/File1.class
+
+$ exists sub-a/target/scala-2.10/src_managed/main/sub/a/A.java
+$ exists sub-a/target/scala-2.10/classes/sub/a/A.class
+
+$ exists sub-b/target/scala-2.10/src_managed/main/sub/b/B.java
+$ exists sub-b/target/scala-2.10/classes/sub/b/B.class
+
+> clean
+
+-$ exists target/scala-2.10/src_managed/main/multi/File1.java

--- a/src/sbt-test/sbt-protoc/depends-on/test
+++ b/src/sbt-test/sbt-protoc/depends-on/test
@@ -1,14 +1,14 @@
 > compile
 
-$ exists target/scala-2.10/src_managed/main/multi/File1.java
-$ exists target/scala-2.10/classes/multi/File1.class
+> existsSource multi/File1.java
+> existsClass multi/File1.class
 
-$ exists sub-a/target/scala-2.10/src_managed/main/sub/a/A.java
-$ exists sub-a/target/scala-2.10/classes/sub/a/A.class
+> existsASource sub/a/A.java
+> existsAClass sub/a/A.class
 
-$ exists sub-b/target/scala-2.10/src_managed/main/sub/b/B.java
-$ exists sub-b/target/scala-2.10/classes/sub/b/B.class
+> existsBSource sub/b/B.java
+> existsBClass sub/b/B.class
 
 > clean
 
--$ exists target/scala-2.10/src_managed/main/multi/File1.java
+-> existsSource multi/File1.java


### PR DESCRIPTION
#22 and scalapb/sbt-scalapb#1 reference the need to include sub-project protoc sources. I've also run in to this, and I can't think of a reason why you would ever not want to. At the very least I feel this should be an opt-in setting.  

Given the code in the state that it is, sub-project proto-sources will automatically be added as includes.