### PR TITLE
protocIncludeDependencies uses Set instead of Seq

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -204,8 +204,8 @@ object ProtocPlugin extends AutoPlugin with Compat {
   def protocIncludeDependencies: Def.Initialize[Seq[File]] = Def.settingDyn {
     val deps = buildDependencies.value.classpath
 
-    def getAllProjectDeps(ref: ProjectRef)(visited: Set[ProjectRef] = Set(ref)): Seq[ProjectRef] =
-      deps.getOrElse(ref, Seq.empty).map(_.project).filterNot(visited.contains).flatMap(getAllProjectDeps(_)(visited + ref)) :+ ref
+    def getAllProjectDeps(ref: ProjectRef)(visited: Set[ProjectRef] = Set(ref)): Set[ProjectRef] =
+      deps.getOrElse(ref, Seq.empty).map(_.project).toSet.diff(visited).flatMap(getAllProjectDeps(_)(visited + ref)) + ref
 
     val thisProjectDeps = getAllProjectDeps(thisProjectRef.value)()
 


### PR DESCRIPTION
Make the function more efficient by returning Set instead of Seq. 
Somehow the stack is still exploded on `0.9.16` on our big repo.