### PR TITLE
Use getAbsolutePath instead of getCanonicalPath in executeProtoc.

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -150,11 +150,11 @@ object ProtocPlugin extends AutoPlugin with Compat {
       log: Logger
   ): Int =
     try {
-      val incPath = includePaths.map("-I" + _.getCanonicalPath)
+      val incPath = includePaths.map("-I" + _.getAbsolutePath)
       protocbridge.ProtocBridge.run(
         protocCommand,
         targets,
-        incPath ++ protocOptions ++ schemas.map(_.getCanonicalPath),
+        incPath ++ protocOptions ++ schemas.map(_.getAbsolutePath),
         pluginFrontend = protocbridge.frontend.PluginFrontend.newInstance
       )
     } catch {


### PR DESCRIPTION
Using getCanonicalPath in executeProtoc has adverse effect in less
standard environments, such as Bazel compilation sandbox -- since
the file is on a path with a symlinked directory, getCanonicalPath
rewrites the path to one outside the sandbox. All the -I arguments
were still inside sandbox, and thus protoc failed with:

``` File does not reside within any path specified using
--proto_path (or -I).  You must specify a --proto_path which
encompasses this file.  Note that the proto_path must be an exact
prefix of the .proto file names -- protoc is too dumb to figure
out when two paths (e.g. absolute and relative) are equivalent
(it's harder than you think). ```

Signed-off-by: Milan Plzik <milan.plzik@ceai.io>