### PR TITLE
Extended UnpackedDependencies to keep mappings to source files

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -139,7 +139,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
   override def projectSettings: Seq[Def.Setting[_]] =
     protobufGlobalSettings ++ inConfig(Compile)(protobufConfigSettings)
 
-  case class UnpackedDependencies(dir: File, mappedFiles: Map[File,Seq[File]]) {
+  case class UnpackedDependencies(dir: File, mappedFiles: Map[File, Seq[File]]) {
     def files: Seq[File] = mappedFiles.values.flatten.toSeq
   }
 
@@ -214,7 +214,11 @@ object ProtocPlugin extends AutoPlugin with Compat {
     }
   }
 
-  private[this] def unpack(deps: Seq[File], extractTarget: File, log: Logger): Seq[(File,Seq[File])] = {
+  private[this] def unpack(
+      deps: Seq[File],
+      extractTarget: File,
+      log: Logger
+  ): Seq[(File, Seq[File])] = {
     IO.createDirectory(extractTarget)
     deps.map { dep =>
       val seq = IO.unzip(dep, extractTarget, "*.proto").toSeq

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -139,7 +139,9 @@ object ProtocPlugin extends AutoPlugin with Compat {
   override def projectSettings: Seq[Def.Setting[_]] =
     protobufGlobalSettings ++ inConfig(Compile)(protobufConfigSettings)
 
-  case class UnpackedDependencies(dir: File, files: Seq[File])
+  case class UnpackedDependencies(dir: File, mappedFiles: Map[File,Seq[File]]) {
+    def files: Seq[File] = mappedFiles.values.flatten.toSeq
+  }
 
   private[this] def executeProtoc(
       protocCommand: Seq[String] => Int,
@@ -212,12 +214,12 @@ object ProtocPlugin extends AutoPlugin with Compat {
     }
   }
 
-  private[this] def unpack(deps: Seq[File], extractTarget: File, log: Logger): Seq[File] = {
+  private[this] def unpack(deps: Seq[File], extractTarget: File, log: Logger): Seq[(File,Seq[File])] = {
     IO.createDirectory(extractTarget)
-    deps.flatMap { dep =>
+    deps.map { dep =>
       val seq = IO.unzip(dep, extractTarget, "*.proto").toSeq
       if (seq.nonEmpty) log.debug("Extracted " + seq.mkString("\n * ", "\n * ", ""))
-      seq
+      dep -> seq
     }
   }
 
@@ -266,7 +268,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
       (PB.externalIncludePath in key).value,
       (streams in key).value.log
     )
-    UnpackedDependencies((PB.externalIncludePath in key).value, extractedFiles)
+    UnpackedDependencies((PB.externalIncludePath in key).value, extractedFiles.toMap)
   }
 
   /**


### PR DESCRIPTION
Protoc plugin nicely unzips protobufs coming as dependencies and returned them as a sequence. Unfortunately it hided the sources of the uziped proto/s. In some use cases user needs to know the connection between sources and uziped files. There was no such an option.
This enhancement  solves the issue with extension of **UnpackedDependencies**. Instead of plain **Seq[File]** it offers a **Map[File, Seq[File]]**. It maps source files to the unziped ones.
To maintain compatibility it still offer files as a plain **Seq[File]**