### PR TITLE
do not run unpackDependencies for each configuration

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -81,6 +81,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
   def protobufGlobalSettings: Seq[Def.Setting[_]] = Seq(
     includeFilter in PB.generate := "*.proto",
     PB.externalIncludePath := target.value / "protobuf_external",
+    PB.unpackDependencies := unpackDependenciesTask(PB.unpackDependencies).value,
     PB.additionalDependencies := {
       val libs = (PB.targets in Compile).value.flatMap(_.generator.suggestedDependencies)
       platformDepsCrossVersion.?.value match {
@@ -121,7 +122,6 @@ object ProtocPlugin extends AutoPlugin with Compat {
     },
     PB.protocOptions := Nil,
     PB.protocOptions := PB.protocOptions.?.value.getOrElse(Nil),
-    PB.unpackDependencies := unpackDependenciesTask(PB.unpackDependencies).value,
     PB.protoSources := PB.protoSources.?.value.getOrElse(Nil),
     PB.protoSources += sourceDirectory.value / "protobuf",
     PB.includePaths := PB.includePaths.?.value.getOrElse(Nil),


### PR DESCRIPTION
As the input and the output are independent of the configuration, the task should only be run once.