### PR TITLE
Revert #16

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -135,14 +135,12 @@ object ProtocPlugin extends AutoPlugin with Compat {
       arguments.previous.exists(_ != arguments.value)
     },
     PB.protocOptions := Nil,
-    PB.protocOptions := PB.protocOptions.?.value.getOrElse(Nil),
-    PB.protoSources := PB.protoSources.?.value.getOrElse(Nil),
+    PB.protoSources := Nil,
     PB.protoSources += sourceDirectory.value / "protobuf",
-    PB.includePaths := PB.includePaths.?.value.getOrElse(Nil),
-    PB.includePaths ++= PB.protoSources.value,
+    PB.includePaths := PB.protoSources.value,
     PB.includePaths += PB.externalIncludePath.value,
     PB.dependentProjectsIncludePaths := protocIncludeDependencies.value,
-    PB.targets := PB.targets.?.value.getOrElse(Nil),
+    PB.targets := Nil,
     PB.generate := sourceGeneratorTask(PB.generate).dependsOn(PB.unpackDependencies).value,
     PB.runProtoc := { args =>
       com.github.os72.protocjar.Protoc.runProtoc(PB.protocVersion.value +: args.toArray)

--- a/src/sbt-test/sbt-protoc/testconfig/build.sbt
+++ b/src/sbt-test/sbt-protoc/testconfig/build.sbt
@@ -1,3 +1,5 @@
+Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
+
 val protobufVersion = "3.7.0"
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
@@ -5,8 +7,6 @@ libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion
 PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value)
 
 PB.targets in Test := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Test).value)
-
-Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
 
 commands ++= List(existsSource, existsClass, existsTestClass, existsTestSource)
 


### PR DESCRIPTION
Fixes #108 

This reverts commit aa1deadbb683eb9b4e054ac7c9d73c6f7e7a3d0a, as scope delegation causes children configurations (i.e `Test`) to inherit values from their parents (`Compile`), forcing plugins to override the keys rather than appending their own values, which makes it impossible to use several plugins affecting them.