### PR TITLE
Show the origin (jar file) of the extracted proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,12 @@ in the `Test` scope.
 ```scala
 inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
 ```
+
+Debugging
+---------
+
+Show proto files extracted and where there are comming from:
+ ```scala
+sbt> set logLevel := Level.Debug
+sbt> protocUnpackDependencies
+ ```

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -240,7 +240,8 @@ object ProtocPlugin extends AutoPlugin with Compat {
         IO.createDirectory(extractTarget)
         deps.flatMap { dep =>
           val set = IO.unzip(dep, extractTarget, "*.proto")
-          if (set.nonEmpty) streams.log.debug("Extracted from " + dep + set.mkString("\n * ", "\n * ", ""))
+          if (set.nonEmpty)
+            streams.log.debug("Extracted from " + dep + set.mkString("\n * ", "\n * ", ""))
           set
         }
       }

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -240,7 +240,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
         IO.createDirectory(extractTarget)
         deps.flatMap { dep =>
           val set = IO.unzip(dep, extractTarget, "*.proto")
-          if (set.nonEmpty) streams.log.debug("Extracted " + set.mkString("\n * ", "\n * ", ""))
+          if (set.nonEmpty) streams.log.debug("Extracted from " + dep + set.mkString("\n * ", "\n * ", ""))
           set
         }
       }

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -241,7 +241,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
         deps.flatMap { dep =>
           val set = IO.unzip(dep, extractTarget, "*.proto")
           if (set.nonEmpty)
-            streams.log.debug("Extracted from " + dep + set.mkString("\n * ", "\n * ", ""))
+            streams.log.debug("Extracted from " + dep + set.mkString(":\n * ", "\n * ", ""))
           set
         }
       }


### PR DESCRIPTION
Hey folks,

This is a small to change to improve the debugging of the task `protocUnpackDependencies`.

Before, only the proto file was logged.
```
[debug] Extracted
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/timestamp.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/wrappers.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/compiler/plugin.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/duration.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/api.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/empty.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/any.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/source_context.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/struct.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/descriptor.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/field_mask.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/type.proto
```

Now, the origin (the jar file) is logged as well.
```
[debug] Extracted from /Users/user/.coursier/cache/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.8.0/protobuf-java-3.8.0.jar
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/timestamp.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/wrappers.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/compiler/plugin.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/duration.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/api.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/empty.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/any.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/source_context.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/struct.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/descriptor.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/field_mask.proto
[debug]  * /Users/user/project/target/protobuf_external/google/protobuf/type.proto
```

Cheers