### PR TITLE
Improve logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 
 libraryDependencies ++= Seq(
   "com.github.os72"      % "protoc-jar"     % "3.7.1",
-  "com.thesamet.scalapb" %% "protoc-bridge" % "0.7.13"
+  "com.thesamet.scalapb" %% "protoc-bridge" % "0.7.13",
+  "org.scalatest"        %% "scalatest"     % "3.0.8" % "test"
 )
 
 enablePlugins(SbtPlugin)

--- a/src/main/scala/sbtprotoc/LoggingOutputStream.scala
+++ b/src/main/scala/sbtprotoc/LoggingOutputStream.scala
@@ -1,0 +1,37 @@
+package sbtprotoc
+
+import java.io.{ByteArrayOutputStream, OutputStream}
+
+import sbt.{Level, Logger}
+
+/** Split an OutputStream into messages and feed them to a given logger at a specified level. Not thread-safe. */
+class LoggingOutputStream(logger: Logger, level: Level.Value, separator: String)
+    extends OutputStream {
+  private val baos = new ByteArrayOutputStream {
+    def maybeStripSuffix(suffix: Array[Byte]): Option[String] = {
+      def endsWithSuffix: Boolean = count >= suffix.length && suffix.zipWithIndex.forall {
+        case (b: Byte, i: Int) =>
+          b == buf(count - separatorBytes.length + i)
+      }
+
+      if (endsWithSuffix) Some(new String(buf, 0, count - separatorBytes.length))
+      else None
+    }
+  }
+
+  private val separatorBytes = separator.getBytes
+  require(separatorBytes.length > 0)
+
+  override def write(b: Int): Unit = {
+    baos.write(b)
+    baos.maybeStripSuffix(separatorBytes).foreach { message =>
+      logger.log(level, message)
+      baos.reset()
+    }
+  }
+}
+
+object LoggingOutputStream {
+  def apply(logger: Logger, level: Level.Value): OutputStream =
+    new LoggingOutputStream(logger, level, System.lineSeparator)
+}

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -217,11 +217,6 @@ object ProtocPlugin extends AutoPlugin with Compat {
       if (exitCode != 0)
         sys.error("protoc returned exit code: %d" format exitCode)
 
-      log.info("Compiling protobuf")
-      generatedTargetDirs.foreach { dir =>
-        log.info("Protoc target directory: %s".format(dir.absolutePath))
-      }
-
       targets.flatMap { ot =>
         (ot.outputPath ** ("*.java" | "*.scala")).get
       }.toSet

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -210,7 +210,7 @@ object ProtocPlugin extends AutoPlugin with Compat {
       )
       log.debug("protoc options:")
       protocOptions.map("\t" + _).foreach(log.debug(_))
-      schemas.foreach(schema => log.info("Compiling schema %s" format schema))
+      schemas.foreach(schema => log.debug("Compiling schema %s" format schema))
 
       val exitCode =
         executeProtoc(protocCommand, schemas, includePaths, protocOptions, targets, log)

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -2,7 +2,7 @@ package sbtprotoc
 
 import sbt._
 import Keys._
-import java.io.{ByteArrayOutputStream, File, OutputStream}
+import java.io.File
 
 import com.github.os72.protocjar.Protoc
 import protocbridge.Target
@@ -310,26 +310,13 @@ object ProtocPlugin extends AutoPlugin with Compat {
       }
     }
 
-  // Forward lines from an OutputStream to a given logger at a specified level
-  private class LoggingOutputStream(logger: Logger, level: Level.Value) extends OutputStream {
-    private val baos = new ByteArrayOutputStream
-    override def write(b: Int): Unit = {
-      baos.write(b)
-      val lineSoFar = baos.toString
-      if (lineSoFar.endsWith(System.lineSeparator)) {
-        logger.log(level, lineSoFar.stripSuffix(System.lineSeparator))
-        baos.reset
-      }
-    }
-  }
-
   private[this] def runProtocTask(
       streams: TaskKey[TaskStreams]
   ): Def.Initialize[Task[Seq[String] => Int]] =
     Def.task {
       val logger = streams.value.log
-      val toInfo = new LoggingOutputStream(logger, Level.Info)
-      val toWarn = new LoggingOutputStream(logger, Level.Warn)
+      val toInfo = LoggingOutputStream(logger, Level.Info)
+      val toWarn = LoggingOutputStream(logger, Level.Warn)
       args => Protoc.runProtoc(PB.protocVersion.value +: args.toArray, toInfo, toWarn)
     }
 

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -188,6 +188,13 @@ object ProtocPlugin extends AutoPlugin with Compat {
       deleteTargetDirectory: Boolean,
       log: Logger
   ) = {
+    targets.groupBy(t => (t.generator, t.outputPath)).foreach {
+      case ((gen, outputPath), targetsForGenAndPath) =>
+        val times = targetsForGenAndPath.length
+        if (times > 1)
+          log.warn(s"Generator ${gen.name} used $times times on the same output path $outputPath")
+    }
+
     // Sort by the length of path names to ensure that delete parent directories before deleting child directories.
     val generatedTargetDirs = targets.map(_.outputPath).sortBy(_.getAbsolutePath.length)
     generatedTargetDirs.foreach { targetDir =>

--- a/src/test/scala/sbtprotoc/LoggingOutputStreamSpec.scala
+++ b/src/test/scala/sbtprotoc/LoggingOutputStreamSpec.scala
@@ -1,0 +1,127 @@
+package sbtprotoc
+
+import java.io.PrintStream
+
+import org.scalatest.{FlatSpec, MustMatchers}
+import sbt.{Level, Logger}
+
+import scala.collection.mutable
+
+class LoggingoutputStreamSpec extends FlatSpec with MustMatchers {
+  val sep  = System.lineSeparator
+  val CRLF = "\r\n"
+
+  def withStubLogger(
+      level: Level.Value,
+      separator: String = sep
+  )(testCode: (LoggingOutputStream, mutable.Seq[(Level.Value, String)]) => Any): Any = {
+    val logs = mutable.ListBuffer[(Level.Value, String)]()
+
+    val logger = new Logger {
+      override def log(level: Level.Value, message: => String): Unit =
+        logs += ((level, message))
+
+      override def success(message: => String): Unit = ???
+      override def trace(t: => Throwable): Unit      = ???
+    }
+
+    testCode(new LoggingOutputStream(logger, level, separator), logs)
+  }
+
+  it should "capture objects printed through PrintStream.println" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val data = 1234
+      new PrintStream(outputStream).println(data)
+      logs must be(mutable.Seq((Level.Warn, String.valueOf(data))))
+    }
+
+  it should "capture messages of increasing length" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val word        = "foo"
+      val printStream = new PrintStream(outputStream)
+      printStream.println(word)
+      printStream.println(word * 2)
+      printStream.println(word * 3)
+      logs.map(_._2) must be(mutable.Seq(word, word * 2, word * 3))
+    }
+
+  it should "capture messages of decreasing length" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val word        = "foo"
+      val printStream = new PrintStream(outputStream)
+      printStream.println(word * 3)
+      printStream.println(word * 2)
+      printStream.println(word)
+      logs.map(_._2) must be(mutable.Seq(word * 3, word * 2, word))
+    }
+
+  it should "capture messages of non-monotonic length" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val word        = "foo"
+      val printStream = new PrintStream(outputStream)
+      printStream.println(word * 3)
+      printStream.println(word)
+      printStream.println(word * 2)
+      logs.map(_._2) must be(mutable.Seq(word * 3, word, word * 2))
+    }
+
+  it should "capture heading empty message" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val message = "hello world!"
+      outputStream.write(s"$sep$message$sep".getBytes)
+      logs.map(_._2) must be(mutable.Seq("", message))
+    }
+
+  it should "capture in-between empty message" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val message1 = "hello world!"
+      val message2 = "here we are"
+      outputStream.write(s"$message1$sep$sep$message2$sep".stripMargin.getBytes)
+      logs.map(_._2) must be(mutable.Seq(message1, "", message2))
+    }
+
+  it should "capture trailing empty message" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val message = "hello world!"
+      outputStream.write(s"$message$sep$sep".getBytes)
+      logs.map(_._2) must be(mutable.Seq(message, ""))
+    }
+
+  it should "capture multi-byte characters" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val messageWithNonAsciiChar = "il était un petit navire"
+      messageWithNonAsciiChar.getBytes.length must be > messageWithNonAsciiChar.length //assert test is correct
+      outputStream.write(s"$messageWithNonAsciiChar$sep".getBytes)
+      logs.map(_._2) must be(mutable.Seq(messageWithNonAsciiChar))
+    }
+
+  it should "handle multi-character separator" in
+    withStubLogger(Level.Warn, CRLF) { (outputStream, logs) =>
+      val message1 = "hello world!"
+      val message2 = "here we are"
+      outputStream.write(s"$message1$CRLF$CRLF$message2$CRLF".getBytes)
+      logs.map(_._2) must be(mutable.Seq(message1, "", message2))
+    }
+
+  it should "be able to capture very long messages" in
+    withStubLogger(Level.Warn) { (outputStream, logs) =>
+      val veryLongMessage = "a" * 1000000 // this would exhaust memory on quadratic implementations
+      outputStream.write(s"$veryLongMessage$sep".getBytes)
+      logs.map(_._2) must be(mutable.Seq(veryLongMessage))
+    }
+
+  it should "be able to capture very long messages containing a subset of the line separator" in
+    withStubLogger(Level.Warn, CRLF) { (outputStream, logs) =>
+      val veryLongMessage = CRLF.head.toString * 1000000
+      outputStream.write(s"$veryLongMessage$CRLF".getBytes)
+      logs.map(_._2) must be(mutable.Seq(veryLongMessage))
+    }
+
+  it should "fail verbosely for invalid separator" in {
+    an[IllegalArgumentException] should be thrownBy new LoggingOutputStream(
+      Logger.Null,
+      Level.Warn,
+      separator = ""
+    )
+  }
+}


### PR DESCRIPTION
See commit descriptions.

Apart from the first commit (preventing misuses of https://github.com/scalapb/protoc-bridge/pull/52), this aims at making the plugin more usable on repos with many projects containing protos (10+). It's currently hard to understand what/where something went wrong when `protocGenerate` is invoked via aggregation on all of them, given the overload of information, and the lack of details when invoking `last` to troubleshoot a particular project.

~Regarding the `System.out.println` interception: I initially started to hack `protoc-jar` to be add a debug outputstream in the signature, but this turned out to be quite some changes which might not get in. So I decided to leave `protoc-jar` un changed and do some thread local magic here instead, which seems to be suggested by other people like in https://github.com/sbt/sbt/issues/1706#issuecomment-63592655.~ See https://github.com/thesamet/sbt-protoc/pull/121#discussion_r344897106