### PR TITLE
Include `protobuf` among useful directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   with the provided arguments and returns it exit code. SBT's logging facilities are provided to the protoc process.
 * NixOS workarounds: if the environment variable `NIX_CC` is present, it is used to locate a dynamic linker (by reading `$NIX_CC/nix-support/dynamic-linker`). The located dynamic linker is used to run `protoc.exe` as well as downloaded native plugins, for seamless development experience in nix-shell. See #505.
 * Deprecated and ignored setting key pythonExe has been removed.
+* The `protobuf` source directory is now part of
+  * `unmanagedSourceDirectories` so that your IDE will take it as a part of your project and
+  * `unmanagedResourceDirectories` so that the `.proto` files will be packed into the resulting JAR.
 
 ## [0.99.31]
 

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -297,7 +297,9 @@ object ProtocPlugin extends AutoPlugin {
           val name = file.getName
           name.endsWith(".java") || name.endsWith(".scala")
         })
-        .taskValue
+        .taskValue,
+      unmanagedResourceDirectories += sourceDirectory.value / "protobuf",
+      unmanagedSourceDirectories += sourceDirectory.value / "protobuf"
     )
 
   override def projectSettings: Seq[Def.Setting[_]] =

--- a/src/sbt-test/settings/include-protos-in-jar/build.sbt
+++ b/src/sbt-test/settings/include-protos-in-jar/build.sbt
@@ -4,12 +4,10 @@ libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion
 
 excludeFilter in PB.generate := "test1.proto"
 
-unmanagedResourceDirectories in Compile ++= (PB.protoSources in Compile).value
-
 TaskKey[Unit]("checkJar") := {
   val binary = (packageBin in Compile).value
-  IO.withTemporaryDirectory{ dir =>
-    val files = IO.unzip(binary, dir, "*.proto")
+  IO.withTemporaryDirectory { dir =>
+    val files  = IO.unzip(binary, dir, "*.proto")
     val expect = Set("test1.proto", "test2.proto").map(dir / _)
     assert(files == expect, s"$files $expect")
   }


### PR DESCRIPTION
IDEs will recognize `protobuf` as directory containing sources.
`.proto` files will be added to the resulting JAR, so that they can be referenced by the downstream users of such Protobuf definitions.

These are good defaults, but are still overridable by the users.
