### PR TITLE
Use consistent ordering of input files.

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -355,7 +355,7 @@ object ProtocPlugin extends AutoPlugin {
       protocbridge.ProtocBridge.run(
         protocCommand,
         targets,
-        incPath ++ protocOptions ++ schemas.map(_.getAbsolutePath),
+        incPath ++ protocOptions ++ schemas.toSeq.map(_.getAbsolutePath).sorted, // sorted to ensure consistent ordering between calls
         pluginFrontend = protocbridge.frontend.PluginFrontend.newInstance,
         classLoader = sandboxedLoader
       )

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -355,7 +355,9 @@ object ProtocPlugin extends AutoPlugin {
       protocbridge.ProtocBridge.run(
         protocCommand,
         targets,
-        incPath ++ protocOptions ++ schemas.toSeq.map(_.getAbsolutePath).sorted, // sorted to ensure consistent ordering between calls
+        incPath ++ protocOptions ++ schemas.toSeq
+          .map(_.getAbsolutePath)
+          .sorted, // sorted to ensure consistent ordering between calls
         pluginFrontend = protocbridge.frontend.PluginFrontend.newInstance,
         classLoader = sandboxedLoader
       )


### PR DESCRIPTION
This change ensures that files provided to protoc are always provided in the same order between invocations.
This shouldn't change anything in most cases, but some plugins do behave differently based on the order of files provided in their input.
There's no "correct" ordering, but a consistent one will avoid these plugins from producing different output between runs with the same input.