### PR TITLE
Lift definition of keys that are not module-specific to the Global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ you probably want `Compile`)
 
 Example settings:
 ```scala
+// Force the version for the protoc binary
+PB.protocVersion := "3.11.4"
+
 // Additional directories to search for imports:
 PB.includePaths in Compile ++= Seq(file("/some/other/path"))
 

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -152,7 +152,7 @@ object ProtocPlugin extends AutoPlugin {
     protobufProjectSettings ++ inConfig(Compile)(protobufConfigSettings) ++
       inConfig(Test)(protobufConfigSettings)
 
-  private[this] def protobufGlobalSettings: Seq[Def.Setting[_]] =
+  private[this] val protobufGlobalSettings: Seq[Def.Setting[_]] =
     Seq(
       PB.protocVersion := "3.11.4",
       PB.deleteTargetDirectory := true,
@@ -189,7 +189,7 @@ object ProtocPlugin extends AutoPlugin {
       concurrentRestrictions += Tags.limit(ProtocDownload, 1)
     )
 
-  private[this] def protobufProjectSettings: Seq[Def.Setting[_]] =
+  private[this] val protobufProjectSettings: Seq[Def.Setting[_]] =
     Seq(
       PB.externalIncludePath := target.value / "protobuf_external",
       PB.externalSourcePath := target.value / "protobuf_external_src",
@@ -255,7 +255,7 @@ object ProtocPlugin extends AutoPlugin {
     )
 
   // Settings that are applied at configuration (Compile, Test) scope.
-  def protobufConfigSettings: Seq[Setting[_]] =
+  val protobufConfigSettings: Seq[Setting[_]] =
     Seq(
       arguments := Arguments(
         includePaths = PB.includePaths.value,


### PR DESCRIPTION
This reduces the [amount of key references](https://github.com/sbt/sbt/blob/30e4c02c9c74db093dec21b31b5f8ae30a2ef6ff/main/src/main/scala/sbt/internal/Load.scala#L257) that the plugin brings (by ~350 on a project with 16 modules where akka-grpc is enabled - this can probably be improved further by leveraging this in akka-grpc).

* The first commit is a no-op functionally, as constants can always be declared "higher" in the scope delegation hierarchy, without impacting the ability for clients to redefine them at any scope.
* The second commit is a follow-up of https://github.com/thesamet/sbt-protoc/commit/20b2a2a75a4c336511a16c6b5f58423ef1d3bcc2#r41705732. The benefit is that we don't need to retrieve and store a ~5MB local binary for every single module where the plugin is enabled - there is of course a Coursier cache, but it does add a bit of runtime overhead on cold builds, and storage overhead everywhere.
* Last commit is not really related, but cannot hurt