### PR TITLE
use (baseDirectory in LocalRootProject).value

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ libraryDependencies ++= Seq(
 )
 
 // Changing where to look for protos to compile (default src/main/protobuf):
-PB.protoSources in Compile := Seq(sourceDirectory.value / "somewhere")
+// this looks are the files using relative path from your project root
+PB.protoSources in Compile := Seq((baseDirectory in LocalRootProject).value / ".." / "somewhere")
 
 // Additional options to pass to protoc:
 PB.protocOptions in Compile := Seq("-xyz")


### PR DESCRIPTION
use `(baseDirectory in LocalRootProject).value` instead of `sourceDirectory.value`. for more context, please refer to https://github.com/thesamet/sbt-protoc/pull/202#issuecomment-740919965