### PR TITLE
use sbt 1.1+ slash notation to reference keys in docs & implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.10"
 If you only want to generate Java code:
 
 ```scala
-PB.targets in Compile := Seq(
-  PB.gens.java -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  PB.gens.java -> (Compile / sourceManaged).value
 )
 ```
 
@@ -41,23 +41,23 @@ A version of `protobuf-java` is going to get added to the runtime
 dependencies. To explicitly set this version you can write:
 
 ```scala
-PB.targets in Compile := Seq(
-  PB.gens.java("3.7.0") -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  PB.gens.java("3.7.0") -> (Compile / sourceManaged).value
 )
 ```
 
 For ScalaPB:
 ```scala
-PB.targets in Compile := Seq(
-  scalapb.gen() -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  scalapb.gen() -> (Compile / sourceManaged).value
 )
 ```
 
 To generate Java + Scala with Java conversions:
 ```scala
-PB.targets in Compile := Seq(
-  PB.gens.java -> (sourceManaged in Compile).value,
-  scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  PB.gens.java -> (Compile / sourceManaged).value,
+  scalapb.gen(javaConversions = true) -> (Compile / sourceManaged).value
 )
 ```
 
@@ -82,8 +82,8 @@ To download an artifact and use it as a code generator plugin:
 ```scala
 libraryDependencies += "io.grpc" % "protoc-gen-grpc-java" % "1.23.0" asProtocPlugin()
 
-PB.targets in Compile := Seq(
-  PB.gens.plugin("grpc-java") -> (sourceManaged in Compile).value,
+Compile / PB.targets := Seq(
+  PB.gens.plugin("grpc-java") -> (Compile / sourceManaged).value,
 )
 ```
 
@@ -99,8 +99,8 @@ different pattern.
 
 ## To invoke a plugin that is already locally installed
 
-    PB.targets in Compile := Seq(
-      PB.gens.plugin(name="myplugin", path="/path/to/plugin") -> (sourceManaged in Compile).value / "js"
+    Compile / PB.targets := Seq(
+      PB.gens.plugin(name="myplugin", path="/path/to/plugin") -> (Compile / sourceManaged).value / "js"
     )
 
 If you need to pass parameters to the plugin, it can be done as follows:
@@ -110,8 +110,8 @@ If you need to pass parameters to the plugin, it can be done as follows:
       path="/usr/local/bin/protoc-gen-grpc-web-1.0.7-linux-x86_64"
     )
 
-    PB.targets in Compile := Seq(
-      (grpcWebGen, Seq("mode=grpcwebtext")) -> (sourceManaged in Compile).value / "js"
+    Compile / PB.targets := Seq(
+      (grpcWebGen, Seq("mode=grpcwebtext")) -> (Compile / sourceManaged).value / "js"
     )
 
 **Step 3: Put some protos in src/main/protobuf and compile**
@@ -128,7 +128,7 @@ Example settings:
 PB.protocVersion := "3.11.4"
 
 // Additional directories to search for imports:
-PB.includePaths in Compile ++= Seq(file("/some/other/path"))
+Compile / PB.includePaths ++= Seq(file("/some/other/path"))
 
 // Make protos from some Jar available to import.
 libraryDependencies ++= Seq(
@@ -145,20 +145,20 @@ libraryDependencies ++= Seq(
 )
 
 // Changing where to look for protos to compile (default src/main/protobuf):
-PB.protoSources in Compile := Seq(sourceDirectory.value / "somewhere")
+Compile / PB.protoSources := Seq(sourceDirectory.value / "somewhere")
 
 // Additional options to pass to protoc:
-PB.protocOptions in Compile := Seq("-xyz")
+Compile / PB.protocOptions := Seq("-xyz")
 
 // Excluding some proto files:
-excludeFilter in PB.generate := "test-*.proto"
+PB.generate / excludeFilter := "test-*.proto"
 
 // Rarely needed: override where proto files from library dependencies are
 // extracted to:
-PB.externalIncludePath in Compile := file("/tmp/foo")
+Compile / PB.externalIncludePath := file("/tmp/foo")
 
 // By default we generate into target/src_managed. To customize:
-PB.targets in Compile := Seq(
+Compile / PB.targets := Seq(
   scalapb.gen() -> file("/some/other/dir")
 )
 
@@ -166,7 +166,7 @@ PB.targets in Compile := Seq(
 PB.protocExecutable := file("/path/to/protoc")
 
 // For sbt-protoc < 1.0 only:
-PB.runProtoc in Compile := (args => Process("/path/to/protoc", args)!)
+Compile / PB.runProtoc := (args => Process("/path/to/protoc", args)!)
 
 // Prevents the plugin from adding libraryDependencies to your project
 PB.additionalDependencies := Nil
@@ -189,8 +189,8 @@ but not to your main code.
 
 To do that, add:
 
-    PB.targets in Test := Seq(
-        PB.gens.java("3.11.4") -> (sourceManaged in Test).value
+    Test / PB.targets := Seq(
+        PB.gens.java("3.11.4") -> (Test / sourceManaged).value
     )
 
 If you want to have protos in some other configuration (not `Compile` or
@@ -202,8 +202,8 @@ configs(IntegrationTest)
 
 inConfig(IntegrationTest)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
 
-PB.targets in IntegrationTest := Seq(
-    PB.gens.java("3.11.4") -> (sourceManaged in IntegrationTest).value
+IntegrationTest / PB.targets := Seq(
+    PB.gens.java("3.11.4") -> (IntegrationTest / sourceManaged).value
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ publishMavenStyle := false
 
 bintrayRepository := "sbt-plugins"
 
-bintrayOrganization in bintray := None
+bintray / bintrayOrganization := None
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/examples/custom-gen/build.sbt
+++ b/examples/custom-gen/build.sbt
@@ -1,5 +1,5 @@
-PB.targets in Compile := Seq(
-  scalapb.gen() -> (sourceManaged in Compile).value,
-  MyCodeGenerator -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  scalapb.gen() -> (Compile / sourceManaged).value,
+  MyCodeGenerator -> (Compile / sourceManaged).value
 )
 

--- a/examples/google-apis-external-jar/build.sbt
+++ b/examples/google-apis-external-jar/build.sbt
@@ -19,10 +19,10 @@ lazy val googleCommonProtos = (project in file("google-common-protos"))
     // is going to contain protos from Google's standard protos.  
     // In order to avoid compiling things we don't use, we restrict what's
     // compiled to a subdirectory of protobuf_external
-    PB.protoSources in Compile += target.value / "protobuf_external" / "google" / "type",
+    Compile / PB.protoSources += target.value / "protobuf_external" / "google" / "type",
 
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value
     )
   )
 
@@ -39,8 +39,8 @@ lazy val myProject = (project in file("my-project"))
       GrpcProtosArtifact % "protobuf"
     ),
 
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value
     ),
 
   )

--- a/examples/grpc-java/build.sbt
+++ b/examples/grpc-java/build.sbt
@@ -2,9 +2,9 @@ val grpcJavaVersion = "1.23.0"
 
 libraryDependencies += ("io.grpc" % "protoc-gen-grpc-java" % "1.19.0") asProtocPlugin()
 
-PB.targets in Compile := Seq(
-  PB.gens.java -> (sourceManaged in Compile).value,
-  PB.gens.plugin("grpc-java") -> (sourceManaged in Compile).value,
+Compile / PB.targets := Seq(
+  PB.gens.java -> (Compile / sourceManaged).value,
+  PB.gens.plugin("grpc-java") -> (Compile / sourceManaged).value,
 )
 
 libraryDependencies ++= Seq(

--- a/examples/java-only/build.sbt
+++ b/examples/java-only/build.sbt
@@ -1,1 +1,1 @@
-PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value)
+Compile / PB.targets  := Seq(PB.gens.java -> (Compile / sourceManaged).value)

--- a/examples/multi-with-external-jar/build.sbt
+++ b/examples/multi-with-external-jar/build.sbt
@@ -7,8 +7,8 @@ lazy val externalProtos = (project in file("external-protos"))
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf"
     ),
 
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value
     )
   )
 
@@ -17,7 +17,7 @@ lazy val externalProtos = (project in file("external-protos"))
 lazy val sub1 = (project in file("sub1"))
   .dependsOn(externalProtos)
   .settings(
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value
     ),
   )

--- a/examples/scalajs-multiproject/build.sbt
+++ b/examples/scalajs-multiproject/build.sbt
@@ -4,11 +4,11 @@ ThisBuild / scalaVersion := "2.13.3"
 
 lazy val proto = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("proto"))
   .settings(
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value
     ),
     // The trick is in this line:
-    PB.protoSources in Compile := Seq(file("proto/src/main/protobuf")),
+    Compile / PB.protoSources := Seq(file("proto/src/main/protobuf")),
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"

--- a/examples/scalapb-crossproject/build.sbt
+++ b/examples/scalapb-crossproject/build.sbt
@@ -5,9 +5,9 @@ val sharedSettings = Seq(
   name         := "example",
   version      := "0.1.0",
   scalaVersion := "2.11.12",
-  PB.protoSources in Compile := Seq((baseDirectory in ThisBuild).value / "src"/ "main" / "protobuf"),
-  PB.targets in Compile := Seq(
-    scalapb.gen() -> (sourceManaged in Compile).value / "protos",
+  Compile / PB.protoSources := Seq((ThisBuild / baseDirectory).value / "src"/ "main" / "protobuf"),
+  Compile / PB.targets := Seq(
+    scalapb.gen() -> (Compile / sourceManaged).value / "protos",
   ),
   libraryDependencies += "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion,
   scalaJSUseMainModuleInitializer := true,

--- a/examples/scalapb-dotty/build.sbt
+++ b/examples/scalapb-dotty/build.sbt
@@ -1,3 +1,3 @@
 scalaVersion := "3.0.0-M1"
 
-PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value / "scalapb")
+Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value / "scalapb")

--- a/examples/scalapb-java-conversions/build.sbt
+++ b/examples/scalapb-java-conversions/build.sbt
@@ -1,7 +1,7 @@
 import scalapb.compiler.Version.protobufVersion
 
-PB.targets in Compile := Seq(
-  PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value,
-  scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  PB.gens.java(protobufVersion) -> (Compile / sourceManaged).value,
+  scalapb.gen(javaConversions = true) -> (Compile / sourceManaged).value
 )
 

--- a/examples/scalapb/build.sbt
+++ b/examples/scalapb/build.sbt
@@ -1,2 +1,2 @@
-PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value)
 

--- a/src/sbt-test/compat/scalapb-0.10.3/build.sbt
+++ b/src/sbt-test/compat/scalapb-0.10.3/build.sbt
@@ -2,6 +2,6 @@ import scalapb.compiler.Version.protobufVersion
 
 scalaVersion := "2.13.1"
 
-PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value)
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"

--- a/src/sbt-test/compat/scalapb-0.10.3/test
+++ b/src/sbt-test/compat/scalapb-0.10.3/test
@@ -9,11 +9,11 @@ $ exists target/scala-2.13/classes/test/test2/test2.class
 $ absent target/scala-2.13/src_managed/main/test/Test1.java
 $ absent target/scala-2.13/src_managed/main/test/Test2.java
 
-> set PB.protocOptions in Compile += "invalid argument"
+> set Compile / PB.protocOptions += "invalid argument"
 -> compile
-> set PB.protocOptions in Compile := Nil
+> set Compile / PB.protocOptions := Nil
 > compile
-> set PB.targets in Compile := Seq(scalapb.gen(flatPackage=true) -> (sourceManaged in Compile).value)
+> set Compile / PB.targets := Seq(scalapb.gen(flatPackage=true) -> (Compile / sourceManaged).value)
 > compile
 $ exists target/scala-2.13/src_managed/main/test/test1.scala
 $ absent target/scala-2.13/src_managed/main/test/test1/test1.scala

--- a/src/sbt-test/compat/scalapb-0.10.6/build.sbt
+++ b/src/sbt-test/compat/scalapb-0.10.6/build.sbt
@@ -2,6 +2,6 @@ import scalapb.compiler.Version.protobufVersion
 
 scalaVersion := "2.13.1"
 
-PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value)
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"

--- a/src/sbt-test/compat/scalapb-0.10.6/test
+++ b/src/sbt-test/compat/scalapb-0.10.6/test
@@ -9,11 +9,11 @@ $ exists target/scala-2.13/classes/test/test2/test2.class
 $ absent target/scala-2.13/src_managed/main/test/Test1.java
 $ absent target/scala-2.13/src_managed/main/test/Test2.java
 
-> set PB.protocOptions in Compile += "invalid argument"
+> set Compile / PB.protocOptions += "invalid argument"
 -> compile
-> set PB.protocOptions in Compile := Nil
+> set Compile / PB.protocOptions := Nil
 > compile
-> set PB.targets in Compile := Seq(scalapb.gen(flatPackage=true) -> (sourceManaged in Compile).value)
+> set Compile / PB.targets := Seq(scalapb.gen(flatPackage=true) -> (Compile / sourceManaged).value)
 > compile
 $ exists target/scala-2.13/src_managed/main/test/test1.scala
 $ absent target/scala-2.13/src_managed/main/test/test1/test1.scala

--- a/src/sbt-test/compat/scalapb-0.9/build.sbt
+++ b/src/sbt-test/compat/scalapb-0.9/build.sbt
@@ -2,6 +2,6 @@ import scalapb.compiler.Version.protobufVersion
 
 scalaVersion := "2.13.1"
 
-PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value)
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"

--- a/src/sbt-test/compat/scalapb-0.9/test
+++ b/src/sbt-test/compat/scalapb-0.9/test
@@ -9,11 +9,11 @@ $ exists target/scala-2.13/classes/test/test2/test2.class
 $ absent target/scala-2.13/src_managed/main/test/Test1.java
 $ absent target/scala-2.13/src_managed/main/test/Test2.java
 
-> set PB.protocOptions in Compile += "invalid argument"
+> set Compile / PB.protocOptions += "invalid argument"
 -> compile
-> set PB.protocOptions in Compile := Nil
+> set Compile / PB.protocOptions := Nil
 > compile
-> set PB.targets in Compile := Seq(scalapb.gen(flatPackage=true) -> (sourceManaged in Compile).value)
+> set Compile / PB.targets := Seq(scalapb.gen(flatPackage=true) -> (Compile / sourceManaged).value)
 > compile
 $ exists target/scala-2.13/src_managed/main/test/test1.scala
 $ absent target/scala-2.13/src_managed/main/test/test1/test1.scala

--- a/src/sbt-test/delete/clear-dir/build.sbt
+++ b/src/sbt-test/delete/clear-dir/build.sbt
@@ -1,1 +1,1 @@
-PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(PB.gens.java -> (Compile / sourceManaged).value)

--- a/src/sbt-test/delete/single-file/build.sbt
+++ b/src/sbt-test/delete/single-file/build.sbt
@@ -1,1 +1,1 @@
-PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(PB.gens.java -> (Compile / sourceManaged ).value)

--- a/src/sbt-test/settings/cross-platform/build.sbt
+++ b/src/sbt-test/settings/cross-platform/build.sbt
@@ -5,13 +5,13 @@ val checkDependency = taskKey[Unit]("")
 lazy val crossPlatform = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     scalaVersion := "2.11.12",
-    PB.targets in Compile := Seq(scalapb.gen() -> (sourceManaged in Compile).value)
+    Compile / PB.targets := Seq(scalapb.gen() -> (Compile / sourceManaged).value)
   )
 
 val jvm = crossPlatform.jvm
   .settings(
     checkDependency := {
-      val jarNames = (managedClasspath in Compile).value.map(_.data.getName)
+      val jarNames = (Compile / managedClasspath).value.map(_.data.getName)
       assert(jarNames.contains("scalapb-runtime_2.11-0.7.4.jar"), jarNames)
     }
   )
@@ -19,7 +19,7 @@ val jvm = crossPlatform.jvm
 val js = crossPlatform.js
   .settings(
     checkDependency := {
-      val jarNames = (managedClasspath in Compile).value.map(_.data.getName)
+      val jarNames = (Compile / managedClasspath).value.map(_.data.getName)
       assert(!jarNames.contains("scalapb-runtime_2.11-0.7.4.jar"), jarNames)
       assert(jarNames.contains("scalapb-runtime_sjs0.6_2.11-0.7.4.jar"), jarNames)
     }
@@ -28,7 +28,7 @@ val js = crossPlatform.js
 val native = crossPlatform.native
   .settings(
     checkDependency := {
-      val jarNames = (managedClasspath in Compile).value.map(_.data.getName)
+      val jarNames = (Compile / managedClasspath).value.map(_.data.getName)
       assert(!jarNames.contains("scalapb-runtime_2.11-0.7.4.jar"), jarNames)
       assert(jarNames.contains("scalapb-runtime_native0.3_2.11-0.7.4.jar"), jarNames)
     }

--- a/src/sbt-test/settings/depends-on/build.sbt
+++ b/src/sbt-test/settings/depends-on/build.sbt
@@ -11,8 +11,8 @@ lazy val b = (project in file("sub-b"))
 
 
 lazy val commonSettings = Seq[SettingsDefinition](
-  PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value),
-  PB.targets in Test := Seq(PB.gens.java -> (sourceManaged in Test).value),
+  Compile / PB.targets := Seq(PB.gens.java -> (Compile / sourceManaged).value),
+  Test / PB.targets := Seq(PB.gens.java -> (Test / sourceManaged).value),
   Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
   libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
 )

--- a/src/sbt-test/settings/include-protos-in-jar/build.sbt
+++ b/src/sbt-test/settings/include-protos-in-jar/build.sbt
@@ -2,10 +2,10 @@ val protobufVersion = "3.11.4"
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
 
-excludeFilter in PB.generate := "test1.proto"
+PB.generate / excludeFilter := "test1.proto"
 
 TaskKey[Unit]("checkJar") := {
-  val binary = (packageBin in Compile).value
+  val binary = (Compile / packageBin).value
   IO.withTemporaryDirectory { dir =>
     val files  = IO.unzip(binary, dir, "*.proto")
     val expect = Set("test1.proto", "test2.proto").map(dir / _)
@@ -13,4 +13,4 @@ TaskKey[Unit]("checkJar") := {
   }
 }
 
-PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(PB.gens.java(protobufVersion) -> (Compile / sourceManaged).value)

--- a/src/sbt-test/settings/itconfig/build.sbt
+++ b/src/sbt-test/settings/itconfig/build.sbt
@@ -7,6 +7,6 @@ Defaults.itSettings
 
 Project.inConfig(IntegrationTest)(sbtprotoc.ProtocPlugin.protobufConfigSettings)
 
-PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(PB.gens.java(protobufVersion) -> (Compile / sourceManaged).value)
 
-PB.targets in IntegrationTest := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in IntegrationTest).value)
+IntegrationTest / PB.targets := Seq(PB.gens.java(protobufVersion) -> (IntegrationTest / sourceManaged).value)

--- a/src/sbt-test/settings/non-jvm/build.sbt
+++ b/src/sbt-test/settings/non-jvm/build.sbt
@@ -1,7 +1,7 @@
-PB.targets in Compile := Seq(
-  PB.gens.descriptorSet -> (resourceManaged in Compile).value / "newdirectory" / "descriptorset.pb",
-  PB.gens.js -> (resourceManaged in Compile).value / "js",
-  PB.gens.java -> (sourceManaged in Compile).value
+Compile / PB.targets := Seq(
+  PB.gens.descriptorSet -> (Compile / resourceManaged).value / "newdirectory" / "descriptorset.pb",
+  PB.gens.js -> (Compile / resourceManaged).value / "js",
+  PB.gens.java -> (Compile / sourceManaged).value
 )
 
 Compile / resourceGenerators += (Compile / PB.generate).taskValue

--- a/src/sbt-test/settings/protobuf-src/build.sbt
+++ b/src/sbt-test/settings/protobuf-src/build.sbt
@@ -2,6 +2,6 @@ libraryDependencies += "com.google.api.grpc" % "proto-google-common-protos" % "1
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.11.4" % "protobuf"
 
-PB.targets in Compile := Seq(PB.gens.java("3.11.4") -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(PB.gens.java("3.11.4") -> (Compile / sourceManaged).value)
 
-javacOptions in Compile ++= Seq("-encoding", "UTF-8")
+Compile / javacOptions ++= Seq("-encoding", "UTF-8")

--- a/src/sbt-test/settings/sandboxed/build.sbt
+++ b/src/sbt-test/settings/sandboxed/build.sbt
@@ -14,6 +14,6 @@ val scalaGen = SandboxedJvmGenerator.forModule(
   )
 )
 
-PB.targets in Compile := Seq(scalaGen -> (sourceManaged in Compile).value)
+Compile / PB.targets := Seq(scalaGen -> (Compile / sourceManaged).value)
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.8.0" % "protobuf"

--- a/src/sbt-test/settings/testconfig/build.sbt
+++ b/src/sbt-test/settings/testconfig/build.sbt
@@ -2,8 +2,8 @@ val protobufVersion = "3.11.4"
 
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % protobufVersion % "protobuf"
 
-PB.targets in Compile := Seq(PB.gens.java(protobufVersion) -> (sourceManaged in Compile).value)
-PB.protocOptions in Compile := Seq(s"--descriptor_set_out=${target.value}/descriptor.pb")
+Compile / PB.targets := Seq(PB.gens.java(protobufVersion) -> (Compile / sourceManaged).value)
+Compile / PB.protocOptions := Seq(s"--descriptor_set_out=${target.value}/descriptor.pb")
 
 // append values rather than assigning them so that other plugins can also inject their own
-PB.targets in Test += PB.gens.java(protobufVersion) -> (sourceManaged in Test).value
+Test / PB.targets += PB.gens.java(protobufVersion) -> (Test / sourceManaged).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+ThisBuild / version := "1.0.1-SNAPSHOT"


### PR DESCRIPTION
- support for sbt 0.13 was dropped almost a year ago
- CI runs scripted starting on 1.2.8 so 1.0 is not officially supported
- the slash notation is the recommended/documented one
- keep the sbt shell syntax in scripted since it is more natural