### PR TITLE
Better cache invalidation

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -124,6 +124,7 @@ object ProtocPlugin extends AutoPlugin {
   }
 
   private[sbtprotoc] final case class Arguments(
+      protocVersion: String,
       includePaths: Seq[File],
       protocOptions: Seq[String],
       deleteTargetDirectory: Boolean,
@@ -520,6 +521,7 @@ object ProtocPlugin extends AutoPlugin {
 
       val targets = (key / PB.targets).value
       val arguments = Arguments(
+        PB.protocVersion.value,
         (key / PB.includePaths).value,
         protocOptions = (key / PB.protocOptions).value ++ nativePluginsArgs,
         deleteTargetDirectory = (key / PB.deleteTargetDirectory).value,

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -78,8 +78,8 @@ object ProtocPlugin extends AutoPlugin {
       val protocCache = TaskKey[FileCache[ModuleID]]("protoc-cache", "Cache of protoc executables")
 
       val cacheArtifactResolution = SettingKey[Boolean](
-        "cache-artifact-resolution",
-        "If false, all sandboxed generators will be re-resolved on each invocation. This is useful when a custom PB.artifactResolver returns different files on each invocation."
+        "protoc-cache-artifact-resolution",
+        "If false, all sandboxed generators will be resolved on each invocation. This is useful when a custom PB.artifactResolver returns different files on each invocation."
       )
 
       @deprecated(

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -567,7 +567,8 @@ object ProtocPlugin extends AutoPlugin {
         log.debug("Ignoring cache (PB.recompile := true)")
         compileProto().toSeq
       } else {
-        cachedCompile((arguments, FileInfo.lastModified(schemas))).toSeq
+        val input = schemas ++ arguments.includePaths.allPaths.get
+        cachedCompile((arguments, FileInfo.lastModified(input))).toSeq
       }
     }
 

--- a/src/sbt-test/settings/caching/LocalGen2.scala
+++ b/src/sbt-test/settings/caching/LocalGen2.scala
@@ -1,0 +1,17 @@
+package codegen
+
+import protocbridge.codegen._
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File
+
+object LocalGen extends CodeGenApp {
+  def process(request: CodeGenRequest): CodeGenResponse = {
+    CodeGenResponse.succeed(
+      Seq(
+        File.newBuilder
+          .setName("LocalGen.scala")
+          .setContent("object LocalGen { val version = 2 } ")
+          .build
+      )
+    )
+  }
+}

--- a/src/sbt-test/settings/caching/api/src/main/protobuf/foo.proto
+++ b/src/sbt-test/settings/caching/api/src/main/protobuf/foo.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package mypkg;
+
+import "google/protobuf/timestamp.proto";
+
+message Bar {
+  google.protobuf.Timestamp time = 1;
+}

--- a/src/sbt-test/settings/caching/build.sbt
+++ b/src/sbt-test/settings/caching/build.sbt
@@ -1,0 +1,40 @@
+import java.nio.file.Files
+import java.nio.file.attribute._
+import scala.jdk.CollectionConverters._
+import protocbridge.Target
+
+/** Update the attributes of the file passed as an argument to make it readable or not for the current user,
+  * without updating the "last modified" attribute nor changing the content of the file.
+  *
+  * Preventing read access to files that are input of protoc is a cheap way to check whether protoc is
+  * actually called (as long as there is no prior content hashing done by sbt-protoc) by asserting
+  * on the failure of the next run.
+  */
+val setReadable = inputKey[Unit]("")
+setReadable := {
+  import complete.DefaultParsers._
+  val (file, readable) = (fileParser((ThisBuild / baseDirectory).value) ~ (Space ~> Bool)).parsed
+  if (protocbridge.SystemDetector.detectedClassifier().startsWith("windows")) {
+    val view = Files.getFileAttributeView(file.toPath, classOf[AclFileAttributeView])
+    val updatedAcls = view.getAcl.asScala.map { acl =>
+      val permissions = acl.permissions
+      if (readable) permissions.add(AclEntryPermission.READ_DATA)
+      else permissions.remove(AclEntryPermission.READ_DATA)
+      AclEntry.newBuilder(acl).setPermissions(permissions).build
+    }
+    view.setAcl(updatedAcls.asJava)
+  } else file.setReadable(readable)
+}
+
+lazy val api = (project in file("api"))
+  .settings(
+    Compile / PB.targets := Seq(
+      PB.gens.java -> (Compile / sourceManaged).value,
+      Target(PB.gens.plugin("validate"), (Compile / sourceManaged).value, Seq("lang=java")),
+      scalapb.gen() -> (Compile / sourceManaged).value
+    ),
+    PB.additionalDependencies ++= Seq(
+      "com.google.protobuf"                % "protobuf-java"       % "3.13.0" % "protobuf",
+      ("io.envoyproxy.protoc-gen-validate" % "protoc-gen-validate" % "0.4.0").asProtocPlugin
+    )
+  )

--- a/src/sbt-test/settings/caching/build.sbt
+++ b/src/sbt-test/settings/caching/build.sbt
@@ -49,8 +49,7 @@ lazy val api = (project in file("api"))
           case DummyArtifact => cp
           case other         => oldResolver(other)
         }
-    },
-    PB.cacheClassLoaders := false
+    }
   )
 
 lazy val codegen = (project in file("codegen"))

--- a/src/sbt-test/settings/caching/codegen/src/main/scala/codegen/LocalGen.scala
+++ b/src/sbt-test/settings/caching/codegen/src/main/scala/codegen/LocalGen.scala
@@ -1,0 +1,17 @@
+package codegen
+
+import protocbridge.codegen._
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File
+
+object LocalGen extends CodeGenApp {
+  def process(request: CodeGenRequest): CodeGenResponse = {
+    CodeGenResponse.succeed(
+      Seq(
+        File.newBuilder
+          .setName("LocalGen.scala")
+          .setContent("object LocalGen { val version = 1 } ")
+          .build
+      )
+    )
+  }
+}

--- a/src/sbt-test/settings/caching/project/plugins.sbt
+++ b/src/sbt-test/settings/caching/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.thesamet" % "sbt-protoc" % pluginVersion)
+}
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.9"

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -143,6 +143,16 @@ $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
+# check cache invalidation on protoc-bridge local generator update
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+$ copy-file LocalGen2.scala codegen/src/main/scala/codegen/LocalGen.scala
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
 # caching can be disabled by setting PB.recompile
 > 'set api / Compile / PB.recompile := true'
 > setReadable api/src/main/protobuf/foo.proto true

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -75,6 +75,16 @@ $ mkdir newdir
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
+# check cache invalidation on updated libraryDependencies for protobuf ivy config
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> 'set api / libraryDependencies ~= { _.map { dep => if (dep.name == "protobuf-java") dep.withRevision("3.14.0") else dep } },'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
 # check cache invalidation on missing output
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -1,0 +1,96 @@
+# Note that this scripted assumes that sbt-protoc uses "last modified" rather than a hash to
+# stamp input files. If this was to change, this would yield false negatives and we will  have
+# to find a more advanced instrumentation strategy.
+
+# verify that a second run of protocGenerate does not run protoc by land-mining the input file
+> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto false
+> api/protocGenerate
+
+# check cache invalidation on PB.protocOptions update
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto false
+> 'set api / Compile / PB.protocOptions += "--error_format=msvs"'
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on PB.deleteTargetDirectory update
+> setReadable api/src/main/protobuf/foo.proto true
+> 'set api / Compile / PB.deleteTargetDirectory := false'
+> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto false
+> 'set api / Compile / PB.deleteTargetDirectory := true'
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on source file update
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+$ touch api/src/main/protobuf/foo.proto
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on new/deleted source file
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+$ touch api/src/main/protobuf/new.proto
+> setReadable api/src/main/protobuf/new.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/new.proto true
+> api/protocGenerate
+$ delete api/src/main/protobuf/new.proto
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on new PB.includePath
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+$ mkdir newdir
+> 'set api / Compile / PB.includePaths += (ThisBuild / baseDirectory).value / "newdir"'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on missing output
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+$ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on new generator
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> 'set api / Compile / PB.targets := Seq(PB.gens.java("3.11.0") -> (Compile / crossTarget).value / "src_managed_2")'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on protoc-bridge published generator update
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> reload plugins
+> 'set libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.10"'
+> reload return
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# caching can be disabled by setting PB.recompile
+> 'set api / Compile / PB.recompile := true'
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -13,6 +13,7 @@
 > setReadable api/src/main/protobuf/foo.proto false
 > 'set api / Compile / PB.protocOptions += "--error_format=msvs"'
 -> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
@@ -23,6 +24,7 @@
 > setReadable api/src/main/protobuf/foo.proto false
 > 'set api / Compile / PB.deleteTargetDirectory := true'
 -> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
@@ -31,6 +33,7 @@
 > api/protocGenerate
 $ touch api/src/main/protobuf/foo.proto
 > setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
 -> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
@@ -41,10 +44,12 @@ $ touch api/src/main/protobuf/foo.proto
 $ touch api/src/main/protobuf/new.proto
 > setReadable api/src/main/protobuf/new.proto false
 -> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/new.proto true
 > api/protocGenerate
 $ delete api/src/main/protobuf/new.proto
 > setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
 -> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
@@ -56,6 +61,17 @@ $ mkdir newdir
 > 'set api / Compile / PB.includePaths += (ThisBuild / baseDirectory).value / "newdir"'
 > setReadable api/src/main/protobuf/foo.proto false
 -> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
+# check cache invalidation on updated asProtocPlugin libraryDependencies
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> 'set api / libraryDependencies ~= { _.map { dep => if (dep.name == "protoc-gen-validate") dep.withRevision("0.4.1") else dep } },'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
@@ -65,6 +81,7 @@ $ mkdir newdir
 $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > setReadable api/src/main/protobuf/foo.proto false
 -> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
@@ -73,6 +90,7 @@ $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > api/protocGenerate
 > 'set api / Compile / PB.targets := Seq(PB.gens.java("3.11.0") -> (Compile / crossTarget).value / "src_managed_2")'
 > setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
 -> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
@@ -85,6 +103,7 @@ $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > reload return
 > setReadable api/src/main/protobuf/foo.proto false
 -> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
@@ -93,4 +112,5 @@ $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
 -> api/protocGenerate

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -7,6 +7,16 @@
 > setReadable api/src/main/protobuf/foo.proto false
 > api/protocGenerate
 
+# check cache invalidation on PB.protocVersion update
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto false
+> 'set api / PB.protocVersion := "3.12.0"'
+-> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
 # check cache invalidation on PB.protocOptions update
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -85,6 +85,22 @@ $ mkdir newdir
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
+# check cache invalidation on new/deleted libraryDependencies for protobuf ivy config
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> 'set api / libraryDependencies += "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % "0.4.1" % "protobuf"'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> 'set api / libraryDependencies -= "io.envoyproxy.protoc-gen-validate" % "pgv-java-stub" % "0.4.1" % "protobuf"'
+> setReadable api/src/main/protobuf/foo.proto false
+-> api/protocGenerate
+-> api/protocGenerate
+> setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+
 # check cache invalidation on missing output
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -143,14 +143,23 @@ $ delete api/target/scala-2.12/src_managed/main/mypkg/Foo.java
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
 
-# check cache invalidation on protoc-bridge local generator update
+# check cache invalidation & cacheloader caching on protoc-bridge local generator update
 > setReadable api/src/main/protobuf/foo.proto true
 > api/protocGenerate
+> setReadable codegen/target/scala-2.12/classes/codegen/LocalGen$.class false
+> api/protocGenerate
 $ copy-file LocalGen2.scala codegen/src/main/scala/codegen/LocalGen.scala
+> codegen/compile
+> setReadable codegen/target/scala-2.12/classes/codegen/LocalGen$.class false
+-> api/protocGenerate
+-> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto false
+> setReadable codegen/target/scala-2.12/classes/codegen/LocalGen$.class true
 -> api/protocGenerate
 -> api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto true
+> api/protocGenerate
+> setReadable codegen/target/scala-2.12/classes/codegen/LocalGen$.class false
 > api/protocGenerate
 
 # caching can be disabled by setting PB.recompile


### PR DESCRIPTION
Closes https://github.com/thesamet/sbt-protoc/issues/208

* Only the last commit is relevant for the discussion on https://github.com/thesamet/sbt-protoc/issues/208, but while I set up testing for it, I discovered a few other places where false positive cache hits were possible (which may lead to stale results, particularly when using https://www.scala-sbt.org/1.x/docs/Remote-Caching.html for example).
* Note for reviewers: I have paid special attention to the git commit granularity.
* Despite the exhaustive scripted coverage, I believe this will need to be tried on `sbt-protoc-gen-project` without `PB.cacheClassLoaders := false` (I haven't).