### PR TITLE
Compile protos brought by ProtobufSrcConfig only once per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [1.0.1]
+* Compile protos brought by `ProtobufSrcConfig` only once per project (#219)
+
 ## [1.0.0-RC7]
 * don't inherit parent configs' values for targets/protocOptions (c9ed1c2)
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ If you need to pass parameters to the plugin, it can be done as follows:
 
 **Step 3: Put some protos in src/main/protobuf and compile**
 
-Migration notes to 1.0.0
-------------------------
+Migration notes
+---------------
 
-These notes are for those migrating from sbt-protoc < 1.0.0. 
+#### From sbt-protoc 1.0.0 to 1.0.1
+
+* Protos imported with "protobuf-src" are now compiled only once per project, in the `Compile` configuration.
+  Use `Test / PB.protoSources += PB.externalSourcePath.value` to trigger compilation also in `Test` (the
+  previous behavior).
+
+#### From sbt-protoc < 1.0.0 to 1.0.0
 
 * `PB.protocVersion` now accepts a version in `x.y.z` format (for example, `3.13.0`). Previously,
   this key accepted protoc-jar style version flags such as `-v361`. Version 1.0.x of ScalaPB will

--- a/src/sbt-test/settings/protobuf-src/build.sbt
+++ b/src/sbt-test/settings/protobuf-src/build.sbt
@@ -3,5 +3,6 @@ libraryDependencies += "com.google.api.grpc" % "proto-google-common-protos" % "1
 libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.11.4" % "protobuf"
 
 Compile / PB.targets := Seq(PB.gens.java("3.11.4") -> (Compile / sourceManaged).value)
+Test / PB.targets := Seq(PB.gens.java("3.11.4") -> (Test / sourceManaged).value)
 
 Compile / javacOptions ++= Seq("-encoding", "UTF-8")

--- a/src/sbt-test/settings/protobuf-src/src/test/protobuf/file3.proto
+++ b/src/sbt-test/settings/protobuf-src/src/test/protobuf/file3.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package multi;
 
+import "google/api/quota.proto";
+
 message msg3 {
   int32 thing = 1;
+  google.api.MetricRule rule = 2;
 }

--- a/src/sbt-test/settings/protobuf-src/test
+++ b/src/sbt-test/settings/protobuf-src/test
@@ -4,3 +4,6 @@
 
 $ exists target/scala-2.12/classes/com/google/api/MetricRule.class
 $ absent target/scala-2.12/classes/com/google/protobuf/MessageOptions.class
+
+> test:compile
+$ absent target/scala-2.12/test-classes/com/google/api/MetricRule.class


### PR DESCRIPTION
In our build, having `ProtobufSrcConfig` protos compiled in `Test` (and potentially in `IntegrationTest`) is:
- a waste of time
- a source of problems for the IDE - IntelliJ complains that it finds the same the same `.class` files both in `src` and `test`, preventing test execution
 
I believe there are cases where the client might want to recompile for each configuration, but is that really the expectation?