### PR TITLE
reduce log verbosity

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -429,7 +429,7 @@ object ProtocPlugin extends AutoPlugin {
       )
       log.debug("protoc options:")
       protocOptions.map("\t" + _).foreach(log.debug(_))
-      schemas.foreach(schema => log.info("Compiling schema %s" format schema))
+      schemas.foreach(schema => log.debug("Compiling schema %s" format schema))
 
       val exitCode =
         executeProtoc(protocRunner, schemas, includePaths, protocOptions, targets, sandboxedLoader)


### PR DESCRIPTION
Rationale: on projects with hundreds of files, logs are very verbose, and not really useful as a failure in one of the schema will not be shown right after the "Compiling schema" entry.

Without changing the default log level:
```diff
 [info] [info] Compiling 2 protobuf files to /tmp/sbt_e28c8e2e/target/scala-2.12/akka-grpc/main
-[info] [info] Compiling schema /tmp/sbt_e28c8e2e/src/main/protobuf/package.proto
-[info] [info] Compiling schema /tmp/sbt_e28c8e2e/src/main/protobuf/helloworld.proto
```