### PR TITLE
setting either of the cache keys to false should disable caching

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -578,7 +578,7 @@ object ProtocPlugin extends AutoPlugin {
         Def.task {
           val log      = (key / streams).value.log
           val resolver = (key / PB.artifactResolver).value
-          val cache    = (key / PB.cacheClassLoaders).value || (key / PB.cacheArtifactResolution).value
+          val cache    = (key / PB.cacheClassLoaders).value && (key / PB.cacheArtifactResolution).value
           (artifact: BridgeArtifact) =>
             val (_, classloader) =
               classloaderCache


### PR DESCRIPTION
Since its introduction in https://github.com/thesamet/sbt-protoc/commit/2a730a44b41335e11042e71c4a14af1aa4cd8eae, users willing to get the `cacheArtifactResolution := false` behavior also had to set the deprecated `cacheClassLoaders := false` as well. This was unexpected and this PR fixes that.

For existing (1.0.0) `cacheArtifactResolution := false` users, the expected behavior of https://github.com/thesamet/sbt-protoc/commit/2a730a44b41335e11042e71c4a14af1aa4cd8eae was to assume an unstable `PB.artifactResolver` by precaution and continue re-resolving it, but it's not the case (unless `cacheArtifactResolution := false` was added), so advanced users with an unstable `PB.artifactResolver` might experience stale classloaders during a sbt session. That is a breaking change unfortunately, but since codegen plugins all seem to have a stable `PB.artifactResolver`, it might not be that much of a problem.