### PR TITLE
Reduce the amount of artifact resolution & stamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [1.0.1] (Unreleased)
+## [1.0.2] (Unreleased)
+* Reduce the amount of artifact resolution & stamping (#227)
+* Honor `cacheArtifactResolution := false` (#226)
+* Don't run protoc with only Scalapb-Options-Proto sources (#225)
+
+## [1.0.1]
 * Compile protos brought by `ProtobufSrcConfig` only once per project (#219)
 * Better cache invalidation (#217)
 * A plugin downloaded from a maven repository and injected via `asProtocPlugin()` can now be used in several PB.targets (#220)

--- a/src/sbt-test/settings/caching/project/Count.scala
+++ b/src/sbt-test/settings/caching/project/Count.scala
@@ -1,0 +1,9 @@
+import sbt._
+
+object Count {
+  private var count = 0
+  def incrementAndGet(): Int = {
+    count += 1
+    count
+  }
+}

--- a/src/sbt-test/settings/caching/test
+++ b/src/sbt-test/settings/caching/test
@@ -2,6 +2,22 @@
 # stamp input files. If this was to change, this would yield false negatives and we will  have
 # to find a more advanced instrumentation strategy.
 
+# Verify the effect of PB.cacheArtifactResolution, relying on the build artifactResolver which
+# triggers failures in protocGenerate by returning nothing for the local generator every other time
+> api/protocGenerate
+$ touch api/src/main/protobuf/foo.proto
+> api/protocGenerate
+> 'set api / PB.cacheArtifactResolution := false'
+$ touch api/src/main/protobuf/foo.proto
+-> api/protocGenerate
+$ touch api/src/main/protobuf/foo.proto
+> api/protocGenerate
+> 'set api / PB.cacheArtifactResolution := true'
+$ touch api/src/main/protobuf/foo.proto
+> api/protocGenerate
+$ touch api/src/main/protobuf/foo.proto
+> api/protocGenerate
+
 # verify that a second run of protocGenerate does not run protoc by land-mining the input file
 > api/protocGenerate
 > setReadable api/src/main/protobuf/foo.proto false


### PR DESCRIPTION
While working on a scripted for https://github.com/thesamet/sbt-protoc/pull/226, I realized there were many unnecessary artifact resolution & stamping across projects/configs & invocations, introduced in https://github.com/thesamet/sbt-protoc/pull/217. This saves a few hundred milliseconds for cold `protocGenerate` invocations, bringing performance back to 1.0.0 level (or better for warm invocations as artifact resolution is shared across projects & configs for the entire sbt session).

See commit message for more details.