### PR TITLE
Register PB target directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Reduce the amount of artifact resolution & stamping (#227)
 * Honor `cacheArtifactResolution := false` (#226)
 * Don't run protoc with only Scalapb-Options-Proto sources (#225)
+* Add `PB.targets` directories to `managedSourceDirectories` so that IDEs are aware of the generated sources in them and can provide autocompletion etc.
 
 ## [1.0.1]
 * Compile protos brought by `ProtobufSrcConfig` only once per project (#219)

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -342,7 +342,7 @@ object ProtocPlugin extends AutoPlugin {
         .filterNot(_ == PB.externalSourcePath.value),
       unmanagedSourceDirectories ++= PB.protoSources.value
         .filterNot(_ == PB.externalSourcePath.value),
-      managedSourceDirectories ++= PB.targets.value.map(_.outputPath)
+      managedSourceDirectories ++= PB.targets.value.map(_.outputPath).distinct
     )
 
   case class UnpackedDependency(files: Seq[File], optionProtos: Seq[File])

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -341,7 +341,8 @@ object ProtocPlugin extends AutoPlugin {
       unmanagedResourceDirectories ++= PB.protoSources.value
         .filterNot(_ == PB.externalSourcePath.value),
       unmanagedSourceDirectories ++= PB.protoSources.value
-        .filterNot(_ == PB.externalSourcePath.value)
+        .filterNot(_ == PB.externalSourcePath.value),
+      managedSourceDirectories ++= PB.targets.value.map(_.outputPath)
     )
 
   case class UnpackedDependency(files: Seq[File], optionProtos: Seq[File])


### PR DESCRIPTION
This adds all PB target directories to `managedSourceDirectories`. That is necessary in order for IDEs (like IntelliJ) be aware of the generated sources and provide autocompletion etc.

Some people may choose nested directories under `Compile / sourceManaged` in order to avoid conflicts with other generating sbt plugins (like BuildInfo):
https://github.com/sbt/sbt/issues/1583#issuecomment-262166588
