### PR TITLE
Revert: Add `PB.targets` directories to `managedSourceDirectories`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## [1.0.3] (Unreleased)
-* Revert: Add `PB.targets` directories to `managedSourceDirectories`. IntelliJ has been fixed.
+## [1.0.4] (Unreleased)
+* `PB.targets` directories are no longer added to `managedSourceDirectories` as the underlying bug in intellij which prompted that change has been fixed in IntelliJ 2021.1.1.
+
+## [1.0.3]
+  * This version is published to maven instead of bintray.
 
 ## [1.0.2]
 * Reduce the amount of artifact resolution & stamping (#227)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.0.3] (Unreleased)
+* Revert: Add `PB.targets` directories to `managedSourceDirectories`. IntelliJ has been fixed.
+
 ## [1.0.2]
 * Reduce the amount of artifact resolution & stamping (#227)
 * Honor `cacheArtifactResolution := false` (#226)

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -351,8 +351,7 @@ object ProtocPlugin extends AutoPlugin {
       unmanagedResourceDirectories ++= PB.protoSources.value
         .filterNot(_ == PB.externalSourcePath.value),
       unmanagedSourceDirectories ++= PB.protoSources.value
-        .filterNot(_ == PB.externalSourcePath.value),
-      managedSourceDirectories ++= PB.targets.value.map(_.outputPath).distinct
+        .filterNot(_ == PB.externalSourcePath.value)
     )
 
   case class UnpackedDependency(files: Seq[File], optionProtos: Seq[File])


### PR DESCRIPTION
Reverts https://github.com/thesamet/sbt-protoc/pull/232

IntelliJ has been fixed, tested on 2021.1.1
