### PR TITLE
Add PB.importRoot setting and implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.8]
+* Add option `PB.importRoot` (defaults to `PB.protoSources`) that allows you to set the directory
+that protobuf `import`s will be evaluated in.
+
 ## [1.0.7]
 * Update default protoc to 3.21.7
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ libraryDependencies ++= Seq(
 // Changing where to look for protos to compile (default src/main/protobuf):
 Compile / PB.protoSources := Seq(sourceDirectory.value / "somewhere")
 
+// Changing where to look for relative `import`s (defaults to `PB.protoSources`):
+Compile / PB.importRoot := (Compile / baseDirectory).value / "protos"
+
 // Additional options to pass to protoc:
 Compile / PB.protocOptions := Seq("-xyz")
 

--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -106,6 +106,11 @@ object ProtocPlugin extends AutoPlugin {
       )
       val recompile = TaskKey[Boolean]("protoc-recompile")
 
+      val importRoot = SettingKey[File](
+        "protobuf-import-root",
+        "Directory to use when resolving .proto import directives."
+      )
+
       val Target       = protocbridge.Target
       val gens         = protocbridge.gens
       val ProtocPlugin = "protoc-plugin"
@@ -313,7 +318,10 @@ object ProtocPlugin extends AutoPlugin {
       PB.manifestProcessing := true,
       PB.includePaths := (
         PB.includePaths.?.value.getOrElse(Nil) ++
-          PB.protoSources.value ++
+          (PB.importRoot.?.value match {
+            case None       => PB.protoSources.value
+            case Some(root) => Seq(root)
+          }) ++
           Seq(PB.externalIncludePath.value, PB.externalSourcePath.value) ++
           protocIncludeDependencies.value,
       ).distinct,


### PR DESCRIPTION
We've got a protobuf repo at work we need to pull in called `protobufs`, and the general structure of it looks like:
```
protobufs/
  - android/
  - ios/
  - protos/
    - shared
      - foo.proto
      - bar.proto
      - baz.proto
    - servicename1/
      - svc1_schema.proto
      - .
      - .
      - .
    - servicename2/
      - svc2_schema.proto
        - .
        - .
        - .
```

And the important thing to note, here, is that this has been arranged for the convenience of Bazel. Our microservices are all written in Go with Bazel as a build tool, while our data engineering department uses Scala. We've been using Bazel and Scala so far, but I'm working on migrating away from Bazel to SBT for JVM builds.

`protos/servicename2/svc2_schema.proto` will import things this way:
```
import protos/shared/foo.proto
import protos/shared/bar.proto
import protos/servicename1/svc1_schema.proto
```
and so forth. The already-existing `sbt-protoc` approach produced only protobuf errors about enum values already being defined, so I gave myself a way to directly control where to look for `import`s.