### PR TITLE
Update sbt to 1.9.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.6


### PR DESCRIPTION
This PR updates sbt to 1.9.6 for the purpose of publishing sbt-protoc with a valid Maven pattern now that https://github.com/sbt/sbt/issues/3410 is resolved. This will allow the use of sbt-protoc in enterprise environments.

I tried to make all the tests pass on my MacOS aarch64 laptop in nix-shell but the changes I had to make became quite big and I gave up so I'm only submitting a single commit (updating to sbt 1.9.6) and I hope github workflows will pass.