### PR TITLE
Switch to protoc 4.32.0

### DIFF
--- a/src/main/scala/sbtprotoc/ProtocPlugin.scala
+++ b/src/main/scala/sbtprotoc/ProtocPlugin.scala
@@ -173,7 +173,7 @@ object ProtocPlugin extends AutoPlugin {
 
   private[this] def protobufGlobalSettings: Seq[Def.Setting[_]] =
     Seq(
-      PB.protocVersion                   := "3.21.7",
+      PB.protocVersion                   := "4.32.0",
       PB.deleteTargetDirectory           := true,
       PB.cacheArtifactResolution         := true,
       PB.cacheClassLoaders               := true,


### PR DESCRIPTION
Not sure I understand why, but I noticed that the current protoc version is way behind the latest. This PR is created to update it.